### PR TITLE
Ratifying latest agentic code setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - maintenance
   pull_request:
   schedule:
     - cron: '0 6 4 * *'

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test/tmp
 test/version_tmp
 tmp
 benchmarks
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-07-29
+
+### Fixed
+
+- Made the direct native implementation handle non-contiguous Numo::NArray
+  views safely.
+- Prevented an out-of-bounds native buffer write for rank-16 inputs.
+- Replaced unchecked native size and offset arithmetic with overflow-checked
+  calculations.
+
 ## [1.0.0] - 2026-07-21
 
 ### Added
@@ -44,4 +54,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the native extension to use the maintained Numo C API and removed the
   legacy untyped-data compatibility code.
 
+[1.0.1]: https://github.com/neilslater/convolver/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/neilslater/convolver/compare/v0.3.2...v1.0.0

--- a/ext/convolver/convolve_raw.c
+++ b/ext/convolver/convolve_raw.c
@@ -50,7 +50,7 @@ void convolve_raw(
     int kernel_rank, int *kernel_shape, float *kernel_ptr,
     int out_rank, int *out_shape, float *out_ptr ) {
   int i, j, kernel_size, kernel_aligned, out_size, offset;
-  int out_co_incr[LARGEST_RANK], kernel_co_incr[LARGEST_RANK];
+  int out_co_incr[LARGEST_RANK + 1], kernel_co_incr[LARGEST_RANK + 1];
   int ker_q[LARGEST_RANK], out_q[LARGEST_RANK];
   int *kernel_co_incr_cache;
 

--- a/ext/convolver/convolve_raw.c
+++ b/ext/convolver/convolve_raw.c
@@ -2,22 +2,37 @@
 
 #include "convolve_raw.h"
 
-static inline int size_from_shape( int rank, int *shape ) {
-  int size = 1;
+static inline size_t checked_add( size_t left, size_t right, const char *description ) {
+  if ( right > SIZE_MAX - left ) {
+    rb_raise( rb_eRangeError, "%s exceeds native implementation limit", description );
+  }
+  return left + right;
+}
+
+static inline size_t checked_multiply( size_t left, size_t right, const char *description ) {
+  if ( left != 0 && right > SIZE_MAX / left ) {
+    rb_raise( rb_eRangeError, "%s exceeds native implementation limit", description );
+  }
+  return left * right;
+}
+
+static inline size_t size_from_shape( int rank, const size_t *shape, const char *description ) {
+  size_t size = 1;
   int i;
-  for ( i = 0; i < rank; i++ ) { size *= shape[i]; }
+  for ( i = 0; i < rank; i++ ) {
+    size = checked_multiply( size, shape[i], description );
+  }
   return size;
 }
 
 // Sets reverse indices
-static inline void corner_reset( int rank, int *shape, int *rev_indices ) {
+static inline void corner_reset( int rank, const size_t *shape, size_t *rev_indices ) {
   int i;
   for ( i = 0; i < rank; i++ ) { rev_indices[i] = shape[i] - 1; }
-  return;
 }
 
 // Counts indices down, returns number of ranks that reset
-static inline int corner_dec( int rank, int *shape, int *rev_indices ) {
+static inline int corner_dec( int rank, const size_t *shape, size_t *rev_indices ) {
   int i = 0;
   (void) rank;
   while ( ! rev_indices[i]-- ) {
@@ -28,14 +43,29 @@ static inline int corner_dec( int rank, int *shape, int *rev_indices ) {
 }
 
 // Generates co-increment steps by rank boundaries crossed, for the outer position as inner position is incremented by 1
-static inline void calc_co_increment( int rank, int *outer_shape, int *inner_shape, int *co_increment ) {
-  int i, factor;
+static inline void calc_co_increment(
+    int rank, const size_t *outer_shape, const size_t *inner_shape, size_t *co_increment ) {
+  size_t factor = 1;
+  int i;
   co_increment[0] = 1; // co-increment is always 1 in lowest rank
-  factor = 1;
   for ( i = 0; i < rank; i++ ) {
-    co_increment[i+1] = co_increment[i] + factor * ( outer_shape[i] - inner_shape[i] );
-    factor *= outer_shape[i];
+    size_t skipped = checked_multiply( factor, outer_shape[i] - inner_shape[i], "array offset" );
+    co_increment[i+1] = checked_add( co_increment[i], skipped, "array offset" );
+    factor = checked_multiply( factor, outer_shape[i], "array size" );
   }
+}
+
+static inline size_t maximum_offset(
+    int rank, const size_t *outer_shape, const size_t *inner_shape, const char *description ) {
+  size_t factor = 1;
+  size_t offset = 0;
+  int i;
+  for ( i = 0; i < rank; i++ ) {
+    size_t dimension_offset = checked_multiply( factor, inner_shape[i] - 1, description );
+    offset = checked_add( offset, dimension_offset, description );
+    factor = checked_multiply( factor, outer_shape[i], "array size" );
+  }
+  return offset;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -46,33 +76,46 @@ static inline void calc_co_increment( int rank, int *outer_shape, int *inner_sha
 //
 
 void convolve_raw(
-    int in_rank, int *in_shape, float *in_ptr,
-    int kernel_rank, int *kernel_shape, float *kernel_ptr,
-    int out_rank, int *out_shape, float *out_ptr ) {
-  int i, j, kernel_size, kernel_aligned, out_size, offset;
-  int out_co_incr[LARGEST_RANK + 1], kernel_co_incr[LARGEST_RANK + 1];
-  int ker_q[LARGEST_RANK], out_q[LARGEST_RANK];
-  int *kernel_co_incr_cache;
+    int in_rank, const size_t *in_shape, const float *in_ptr,
+    int kernel_rank, const size_t *kernel_shape, const float *kernel_ptr,
+    int out_rank, const size_t *out_shape, float *out_ptr ) {
+  size_t i, j, input_size, kernel_size, kernel_aligned, out_size, offset;
+  size_t maximum_input_offset;
+  size_t out_co_incr[LARGEST_RANK + 1], kernel_co_incr[LARGEST_RANK + 1];
+  size_t ker_q[LARGEST_RANK], out_q[LARGEST_RANK];
+  size_t *kernel_co_incr_cache;
+  VALUE cache_storage = 0;
 
-  kernel_size = size_from_shape( kernel_rank, kernel_shape );
-  kernel_aligned = 4 * (kernel_size/4);
-  out_size = size_from_shape( out_rank, out_shape );
+  kernel_size = size_from_shape( kernel_rank, kernel_shape, "kernel size" );
+  kernel_aligned = kernel_size - kernel_size % 4;
+  out_size = size_from_shape( out_rank, out_shape, "output size" );
+  input_size = size_from_shape( in_rank, in_shape, "input size" );
 
   calc_co_increment( in_rank, in_shape, out_shape, out_co_incr );
   calc_co_increment( in_rank, in_shape, kernel_shape, kernel_co_incr );
+  maximum_input_offset = checked_add(
+    maximum_offset( in_rank, in_shape, out_shape, "input offset" ),
+    maximum_offset( in_rank, in_shape, kernel_shape, "input offset" ),
+    "input offset"
+  );
+  if ( maximum_input_offset >= input_size ) {
+    rb_raise( rb_eRangeError, "input offset exceeds native implementation limit" );
+  }
 
-  kernel_co_incr_cache = ALLOC_N( int, kernel_size );
+  kernel_co_incr_cache = RB_ALLOCV_N( size_t, cache_storage, kernel_size );
   kernel_co_incr_cache[0] = 0;
 
   corner_reset( kernel_rank, kernel_shape, ker_q );
   for ( i = 1; i < kernel_size; i++ ) {
-    kernel_co_incr_cache[i] = kernel_co_incr_cache[i-1] + kernel_co_incr[ corner_dec( kernel_rank, kernel_shape, ker_q  ) ];
+    kernel_co_incr_cache[i] = checked_add(
+      kernel_co_incr_cache[i-1],
+      kernel_co_incr[ corner_dec( kernel_rank, kernel_shape, ker_q ) ],
+      "kernel offset"
+    );
   }
 
-  // For convenience of flow, we set offset to -1 and adjust countdown 1 higher to compensate
-  offset = -1;
+  offset = 0;
   corner_reset( out_rank, out_shape, out_q );
-  out_q[0]++;
 
   // Main convolve loop
   for ( i = 0; i < out_size; i++ ) {
@@ -82,8 +125,6 @@ void convolve_raw(
     simd_t = _mm_setzero_ps();
 #endif
     float t = 0.0;
-
-    offset += out_co_incr[ corner_dec( out_rank, out_shape, out_q ) ];
 
 #if CONVOLVER_USE_SSE
     // Use SIMD for all the aligned values in groups of 4
@@ -114,8 +155,15 @@ void convolve_raw(
 #else
     out_ptr[i] = t;
 #endif
+
+    if ( i + 1 < out_size ) {
+      offset = checked_add(
+        offset,
+        out_co_incr[ corner_dec( out_rank, out_shape, out_q ) ],
+        "input offset"
+      );
+    }
   }
 
-  xfree( kernel_co_incr_cache );
-  return;
+  RB_ALLOCV_END( cache_storage );
 }

--- a/ext/convolver/convolve_raw.h
+++ b/ext/convolver/convolve_raw.h
@@ -18,8 +18,8 @@
 #define LARGEST_RANK 16
 
 void convolve_raw(
-    int in_rank, int *in_shape, float *in_ptr,
-    int kernel_rank, int *kernel_shape, float *kernel_ptr,
-    int out_rank, int *out_shape, float *out_ptr );
+    int in_rank, const size_t *in_shape, const float *in_ptr,
+    int kernel_rank, const size_t *kernel_shape, const float *kernel_ptr,
+    int out_rank, const size_t *out_shape, float *out_ptr );
 
 #endif

--- a/ext/convolver/convolver.c
+++ b/ext/convolver/convolver.c
@@ -47,6 +47,12 @@ static VALUE convolver_convolve_basic(VALUE self, VALUE signal, VALUE kernel) {
 
   signal_value = rb_funcall(numo_cSFloat, rb_intern("cast"), 1, signal);
   kernel_value = rb_funcall(numo_cSFloat, rb_intern("cast"), 1, kernel);
+  if (!RTEST(na_check_contiguous(signal_value))) {
+    signal_value = na_copy(signal_value);
+  }
+  if (!RTEST(na_check_contiguous(kernel_value))) {
+    kernel_value = na_copy(kernel_value);
+  }
   GetNArray(signal_value, signal_narray);
   GetNArray(kernel_value, kernel_narray);
 

--- a/ext/convolver/convolver.c
+++ b/ext/convolver/convolver.c
@@ -1,4 +1,3 @@
-#include <limits.h>
 #include <ruby.h>
 #include <numo/narray.h>
 #include <numo/intern.h>
@@ -7,14 +6,11 @@
 
 static VALUE mConvolver;
 
-static void copy_shape(int rank, const size_t *source, int *target) {
+static void copy_shape(int rank, const size_t *source, size_t *target) {
   int i;
 
   for (i = 0; i < rank; i++) {
-    if (source[rank - i - 1] > INT_MAX) {
-      rb_raise(rb_eArgError, "array dimension exceeds native implementation limit");
-    }
-    target[i] = (int)source[rank - i - 1];
+    target[i] = source[rank - i - 1];
   }
 }
 
@@ -34,9 +30,9 @@ static VALUE convolver_convolve_basic(VALUE self, VALUE signal, VALUE kernel) {
   narray_t *kernel_narray;
   int rank;
   int i;
-  int signal_shape[LARGEST_RANK];
-  int kernel_shape[LARGEST_RANK];
-  int result_shape[LARGEST_RANK];
+  size_t signal_shape[LARGEST_RANK];
+  size_t kernel_shape[LARGEST_RANK];
+  size_t result_shape[LARGEST_RANK];
   size_t numo_result_shape[LARGEST_RANK];
 
   (void)self;
@@ -72,10 +68,10 @@ static VALUE convolver_convolve_basic(VALUE self, VALUE signal, VALUE kernel) {
   copy_shape(rank, kernel_narray->shape, kernel_shape);
 
   for (i = 0; i < rank; i++) {
-    result_shape[i] = signal_shape[i] - kernel_shape[i] + 1;
-    if (result_shape[i] < 1) {
+    if (signal_shape[i] < kernel_shape[i]) {
       rb_raise(rb_eArgError, "kernel must not be larger than signal in any dimension");
     }
+    result_shape[i] = signal_shape[i] - kernel_shape[i] + 1;
     numo_result_shape[rank - i - 1] = (size_t)result_shape[i];
   }
 

--- a/lib/convolver/version.rb
+++ b/lib/convolver/version.rb
@@ -2,5 +2,5 @@
 
 module Convolver
   # Current gem version.
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/spec/convolver_basic_spec.rb
+++ b/spec/convolver_basic_spec.rb
@@ -128,6 +128,16 @@ describe Convolver do
         .to raise_error(ArgumentError, 'maximum supported rank is 16')
     end
 
+    it 'calculates a convolution at the maximum supported rank' do
+      rank_16_shape = Array.new(16, 1)
+      signal = NArray.ones(*rank_16_shape) * 2
+      kernel = NArray.ones(*rank_16_shape) * 3
+
+      result = described_class.convolve_basic(signal, kernel)
+
+      expect(result).to be_narray_like NArray.ones(*rank_16_shape) * 6
+    end
+
     it 'rejects a kernel larger than the signal' do
       expect { described_class.convolve_basic(NArray.sfloat(2), NArray.sfloat(3)) }
         .to raise_error(ArgumentError, 'kernel must not be larger than signal in any dimension')

--- a/spec/convolver_basic_spec.rb
+++ b/spec/convolver_basic_spec.rb
@@ -28,6 +28,15 @@ describe Convolver do
                                           [1.13, 1.3, 0.83], [1.04, 0.26, 0.77], [1.06, 1.05, 1.04] ]
     end
 
+    it 'calculates a convolution from non-contiguous views' do
+      signal = NArray[[0.3, 0.6, 0.9], [0.4, 0.8, 1.0], [0.5, 0.2, 0.1]].transpose
+      kernel = NArray[[1.2, 0.5], [-0.5, -1.3]].transpose
+
+      result = described_class.convolve_basic(signal, kernel)
+
+      expect(result).to be_narray_like NArray[[-0.58, 0.37], [-0.53, 1.23]]
+    end
+
     it 'calculates a 3D convolution' do
       # 5x4x3
       a = NArray[


### PR DESCRIPTION
## Summary

- prepare the 1.0.1 patch release with the version bump and changelog
- safely materialize non-contiguous Numo::NArray views before direct native convolution
- fix the rank-16 co-increment buffer bounds
- replace unchecked native size and offset arithmetic with checked `size_t` calculations
- run CI on pushes to the maintenance branch and ignore local macOS metadata

## Validation

- `bundle exec rake` — 30 examples, 0 failures
- `bundle exec rubocop` — 10 files inspected, no offenses
- `bundle exec rake c:lint` — strict native compilation passed
- `git diff --check` — passed
