### PR TITLE
Add convolution output and boundary modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `:valid`, `:same`, and `:full` output modes to every calculation and
+  estimator method.
+- Added constant, nearest, reflect, mirror, and wrap signal boundary extensions,
+  including nonzero constant fill and kernels larger than the signal where the
+  output mode permits them.
+- Added scalar and per-axis kernel origins with an explicit even-kernel
+  alignment convention.
+- Added an origin-aware circular PocketFFT correlation path for periodic
+  same-sized output.
+
+### Changed
+
+- Made algorithm selection and both public time estimators account for output
+  shape, boundary extension, kernel folding, and FFT working shape.
+- Moved the native valid-only calculation behind a shared Ruby orchestration
+  layer so direct and FFT implementations use identical option validation and
+  boundary semantics.
+
 ## [1.0.1] - 2026-07-29
 
 ### Fixed
@@ -54,5 +76,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the native extension to use the maintained Numo C API and removed the
   legacy untyped-data compatibility code.
 
+[Unreleased]: https://github.com/neilslater/convolver/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/neilslater/convolver/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/neilslater/convolver/compare/v0.3.2...v1.0.0

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 [![CI](https://github.com/neilslater/convolver/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/neilslater/convolver/actions/workflows/ci.yml)
 [![Gem Version](https://badge.fury.io/rb/convolver.svg)](https://badge.fury.io/rb/convolver)
 
-Convolver calculates valid cross-correlations between multidimensional
-[`Numo::NArray`](https://github.com/yoshoku/numo-narray-alt) values. It chooses
-between a direct native implementation for smaller inputs and a
+Convolver calculates cross-correlations between multidimensional
+[`Numo::NArray`](https://github.com/yoshoku/numo-narray-alt) values, with
+configurable output extents and signal boundary extensions. It chooses between
+a direct native implementation for smaller inputs and a
 [`Numo::Pocketfft`](https://github.com/yoshoku/numo-pocketfft)-based
 implementation for larger inputs.
 
@@ -47,9 +48,10 @@ Convolver.convolve(signal, kernel)
 #    [0.19, 0.27]
 ```
 
-The signal and kernel must have the same rank, and the kernel must be no larger
-than the signal in any dimension. Convolver returns only positions at which the
-kernel overlaps the signal completely. The result size in each dimension is:
+With no keywords, Convolver preserves its original valid-correlation behavior:
+the signal and kernel must have the same rank, the kernel must be no larger
+than the signal in any dimension, and only positions with complete overlap are
+returned. The result size in each dimension is:
 
 ```ruby
 signal_size - kernel_size + 1
@@ -68,8 +70,74 @@ Convolver.convolve_basic(signal, kernel)
 Convolver.convolve_fft(signal, kernel)
 ```
 
+Both implementations and the automatic method accept the same options:
+
+```ruby
+Convolver.convolve(signal, kernel,
+                   mode: :same,
+                   boundary: :reflect,
+                   origin: 0)
+```
+
+### Output modes
+
+`mode:` controls the returned extent independently in each dimension:
+
+| Mode | Meaning | Result size |
+| --- | --- | --- |
+| `:valid` | Kernel overlaps the stored signal completely | `S - K + 1` |
+| `:same` | One result aligned with each stored signal position | `S` |
+| `:full` | Every kernel position with any stored-signal overlap | `S + K - 1` |
+
+`:valid` is the default and accepts only the default `boundary: :constant`,
+`fill_value: 0.0`, and `origin: 0`. `:full` supports constant extension only.
+`:same` supports every boundary described below. Kernels larger than the signal
+are supported by `:same` and `:full`, but not by `:valid`. `mode:` and
+`boundary:` accept only the symbols listed here.
+
+### Boundary extension
+
+For a one-dimensional signal `a b c d`, `boundary:` selects values outside the
+stored signal:
+
+| Boundary | Extended sequence |
+| --- | --- |
+| `:constant` | `k k k k | a b c d | k k k k` |
+| `:nearest` | `a a a a | a b c d | d d d d` |
+| `:reflect` | `d c b a | a b c d | d c b a` |
+| `:mirror` | `d c b | a b c d | c b a` |
+| `:wrap` | `a b c d | a b c d | a b c d` |
+
+`fill_value:` sets `k` for `:constant` and defaults to zero. It must not be
+passed with another boundary. `:reflect` repeats the edge sample; `:mirror`
+does not. All boundary modes work across every dimension, including
+length-one axes and extensions wider than the stored signal.
+
+### Kernel origin
+
+`origin:` shifts the kernel anchor for `:same`. It accepts one integer applied
+to every dimension or an array with one integer per dimension. For a kernel
+dimension of length `K`:
+
+```ruby
+anchor = (K / 2) + origin
+```
+
+The anchor must remain within the kernel. Positive origins sample farther
+toward lower signal indices. With the default origin, an even kernel gives the
+extra boundary sample to the lower-index, or left, side: a length-four kernel
+uses two samples before and one after the aligned signal position. Nonzero
+origins are supported only for `:same`; `:valid` and `:full` require zero.
+
+The estimator methods accept and validate the same options:
+
+```ruby
+Convolver.predict_convolve_basic_time(signal, kernel, mode: :same, boundary: :nearest)
+Convolver.predict_convolve_fft_time(signal, kernel, mode: :same, boundary: :wrap)
+```
+
 `Convolver.convolve_fftw3` remains as a deprecated alias for `convolve_fft` to
-ease migration from Convolver 0.x.
+ease migration from Convolver 0.x and forwards all options.
 
 ## Contributing
 

--- a/convolver.gemspec
+++ b/convolver.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.version       = Convolver::VERSION
   spec.authors       = ['Neil Slater']
   spec.email         = ['slobo777@gmail.com']
-  spec.description   = 'Fast valid cross-correlation for multidimensional Numo::NArray values, ' \
-                       'with native and FFT implementations.'
+  spec.description   = 'Fast cross-correlation for multidimensional Numo::NArray values, ' \
+                       'with configurable output and boundary modes.'
   spec.summary       = 'Fast cross-correlation for Numo::NArray'
   spec.homepage      = 'https://github.com/neilslater/convolver'
   spec.license       = 'MIT'

--- a/ext/convolver/convolver.c
+++ b/ext/convolver/convolver.c
@@ -17,12 +17,12 @@ static void copy_shape(int rank, const size_t *source, size_t *target) {
 /*
  * Calculates a valid cross-correlation using the direct native implementation.
  *
- * @overload convolve_basic(signal, kernel)
+ * @overload convolve_basic_valid(signal, kernel)
  *   @param signal [Numo::NArray] input values
  *   @param kernel [Numo::NArray] correlation kernel
  *   @return [Numo::SFloat] valid cross-correlation result
  */
-static VALUE convolver_convolve_basic(VALUE self, VALUE signal, VALUE kernel) {
+static VALUE convolver_convolve_basic_valid(VALUE self, VALUE signal, VALUE kernel) {
   volatile VALUE signal_value;
   volatile VALUE kernel_value;
   volatile VALUE result_value;
@@ -87,5 +87,5 @@ static VALUE convolver_convolve_basic(VALUE self, VALUE signal, VALUE kernel) {
 
 void Init_convolver(void) {
   mConvolver = rb_define_module("Convolver");
-  rb_define_singleton_method(mConvolver, "convolve_basic", convolver_convolve_basic, 2);
+  rb_define_singleton_method(mConvolver, "convolve_basic_valid", convolver_convolve_basic_valid, 2);
 }

--- a/lib/convolver.rb
+++ b/lib/convolver.rb
@@ -5,105 +5,157 @@ require 'numo/pocketfft'
 require 'convolver/convolver'
 require 'convolver/version'
 
-# Valid cross-correlation operations for Numo::NArray values.
+# Cross-correlation operations for Numo::NArray values.
 module Convolver
-  # Maximum number of dimensions supported by the direct native implementation.
+  # Maximum number of dimensions supported by the implementations.
   MAX_RANK = 16
 
+  require 'convolver/operation_plan'
+
   class << self
-    # Chooses the likely fastest implementation for a valid cross-correlation.
-    #
-    # The inputs must have the same rank, and the kernel must not be larger than
-    # the signal in any dimension. The result shape is:
-    #
-    #   signal.shape.zip(kernel.shape).map { |signal_size, kernel_size| signal_size - kernel_size + 1 }
+    # The accepted public API has two positional and four keyword parameters.
+    # rubocop:disable Metrics/ParameterLists
+    # Chooses the likely fastest cross-correlation implementation.
     #
     # @param signal [Numo::NArray] input values
     # @param kernel [Numo::NArray] correlation kernel
-    # @return [Numo::SFloat] valid cross-correlation result
-    # @raise [ArgumentError] if the inputs have incompatible ranks or shapes
-    def convolve(signal, kernel)
-      validate_inputs!(signal, kernel)
-      return convolve_basic(signal, kernel) if signal.size < 1000 || kernel.size < 100
+    # @param mode [:valid, :same, :full] returned output extent
+    # @param boundary [:constant, :nearest, :reflect, :mirror, :wrap] signal extension
+    # @param fill_value [Numeric] constant extension value
+    # @param origin [Integer, Array<Integer>] kernel origin shift
+    # @return [Numo::SFloat] cross-correlation result
+    # @raise [ArgumentError] if inputs or options are incompatible
+    def convolve(signal, kernel, mode: :valid, boundary: :constant,
+                 fill_value: UNSPECIFIED_FILL, origin: 0)
+      plan = operation_plan(signal, kernel, mode:, boundary:, fill_value:, origin:)
+      options = operation_options(mode, boundary, fill_value, origin)
 
-      basic_time_predicted = predict_convolve_basic_time(signal, kernel)
-      return convolve_basic(signal, kernel) if basic_time_predicted < 0.1
+      return convolve_basic(signal, kernel, **options) if plan.extended_size < 1000 || kernel.size < 100
 
-      fft_time_predicted = predict_convolve_fft_time(signal, kernel)
-      return convolve_fft(signal, kernel) if fft_time_predicted < 2 * basic_time_predicted
+      basic_time_predicted = predict_convolve_basic_time(signal, kernel, **options)
+      return convolve_basic(signal, kernel, **options) if basic_time_predicted < 0.1
 
-      convolve_basic(signal, kernel)
+      fft_time_predicted = predict_convolve_fft_time(signal, kernel, **options)
+      return convolve_fft(signal, kernel, **options) if fft_time_predicted < 2 * basic_time_predicted
+
+      convolve_basic(signal, kernel, **options)
     end
 
-    # Uses PocketFFT to calculate a valid cross-correlation.
+    # Uses the direct native valid primitive after applying the requested signal
+    # extension in Ruby.
     #
-    # @param signal [Numo::NArray] input values
-    # @param kernel [Numo::NArray] correlation kernel
-    # @return [Numo::SFloat] valid cross-correlation result
-    # @raise [ArgumentError] if the inputs have incompatible ranks or shapes
-    def convolve_fft(signal, kernel)
-      validate_inputs!(signal, kernel)
-      ranges = kernel.shape.zip(signal.shape).map { |kernel_size, signal_size| (kernel_size - 1)...signal_size }
-      full_convolution = Numo::Pocketfft.fftconvolve(signal, kernel.reverse)
+    # @return [Numo::SFloat] cross-correlation result
+    def convolve_basic(signal, kernel, mode: :valid, boundary: :constant,
+                       fill_value: UNSPECIFIED_FILL, origin: 0)
+      plan = operation_plan(signal, kernel, mode:, boundary:, fill_value:, origin:)
+      convolve_basic_valid(plan.extend_signal(signal), kernel)
+    end
 
-      Numo::SFloat.cast(full_convolution[*ranges])
+    # Uses PocketFFT to calculate the requested cross-correlation.
+    #
+    # Periodic same-sized results use a circular transform. Other combinations
+    # use the shared extension plan and PocketFFT's linear convolution.
+    #
+    # @return [Numo::SFloat] cross-correlation result
+    def convolve_fft(signal, kernel, mode: :valid, boundary: :constant,
+                     fill_value: UNSPECIFIED_FILL, origin: 0)
+      plan = operation_plan(signal, kernel, mode:, boundary:, fill_value:, origin:)
+      return convolve_fft_wrap(signal, kernel, plan) if plan.wrap?
+
+      convolve_fft_valid(plan.extend_signal(signal), kernel)
     end
 
     # Compatibility alias for the former FFTW3-backed implementation.
     #
     # @deprecated Use {.convolve_fft}; Convolver no longer uses FFTW3.
-    # @return [Numo::SFloat] valid cross-correlation result
-    def convolve_fftw3(signal, kernel)
+    # @return [Numo::SFloat] cross-correlation result
+    def convolve_fftw3(signal, kernel, mode: :valid, boundary: :constant,
+                       fill_value: UNSPECIFIED_FILL, origin: 0)
       warn 'Convolver.convolve_fftw3 is deprecated; use .convolve_fft instead', uplevel: 1
-      convolve_fft(signal, kernel)
+      options = operation_options(mode, boundary, fill_value, origin)
+      convolve_fft(signal, kernel, **options)
     end
 
-    # Estimates the relative cost of {.convolve_fft}.
+    # Estimates the relative cost of {.convolve_fft} for the requested options.
     #
-    # @param signal [Numo::NArray] input values
-    # @param kernel [Numo::NArray] correlation kernel
     # @return [Float] machine-specific relative cost estimate
-    def predict_convolve_fft_time(signal, kernel)
-      validate_inputs!(signal, kernel)
-      output_size = result_shape(signal.shape, kernel.shape).inject(:*)
-      16 * 4.55e-08 * output_size * Math.log(output_size)
+    def predict_convolve_fft_time(signal, kernel, mode: :valid, boundary: :constant,
+                                  fill_value: UNSPECIFIED_FILL, origin: 0)
+      plan = operation_plan(signal, kernel, mode:, boundary:, fill_value:, origin:)
+      transform_size = plan.wrap? ? signal.size : plan.linear_fft_size(kernel.shape)
+      transform_cost = 16 * 4.55e-08 * transform_size * Math.log(transform_size)
+      transform_cost + (4.55e-08 * fft_preparation_size(plan, signal, kernel))
     end
 
-    # Estimates the relative cost of {.convolve_basic}.
+    # Estimates the relative cost of {.convolve_basic} for the requested options.
     #
-    # @param signal [Numo::NArray] input values
-    # @param kernel [Numo::NArray] correlation kernel
     # @return [Float] machine-specific relative cost estimate
-    def predict_convolve_basic_time(signal, kernel)
-      validate_inputs!(signal, kernel)
-      outputs = result_shape(signal.shape, kernel.shape).inject(:*)
-      4.54e-12 * (outputs * signal.size * kernel.size)
+    def predict_convolve_basic_time(signal, kernel, mode: :valid, boundary: :constant,
+                                    fill_value: UNSPECIFIED_FILL, origin: 0)
+      plan = operation_plan(signal, kernel, mode:, boundary:, fill_value:, origin:)
+      operations = plan.result_size * plan.extended_size * kernel.size
+      operations += plan.extended_size unless plan.valid?
+      4.54e-12 * operations
     end
 
     private
 
-    def result_shape(signal_shape, kernel_shape)
-      signal_shape.zip(kernel_shape).map { |signal_size, kernel_size| signal_size - kernel_size + 1 }
+    private :convolve_basic_valid
+
+    def operation_plan(signal, kernel, mode:, boundary:, fill_value:, origin:)
+      OperationPlan.new(signal, kernel, mode:, boundary:, fill_value:, origin:)
     end
 
-    def validate_inputs!(signal, kernel)
-      validate_types!(signal, kernel)
-      validate_shapes!(signal, kernel)
+    def operation_options(mode, boundary, fill_value, origin)
+      options = { mode:, boundary:, origin: }
+      options[:fill_value] = fill_value unless fill_value.equal?(UNSPECIFIED_FILL)
+      options
     end
 
-    def validate_types!(signal, kernel)
-      unless signal.is_a?(Numo::NArray) && kernel.is_a?(Numo::NArray)
-        raise ArgumentError, 'signal and kernel must be Numo::NArray values'
+    def convolve_fft_valid(signal, kernel)
+      ranges = kernel.shape.zip(signal.shape).map do |kernel_size, signal_size|
+        (kernel_size - 1)...signal_size
       end
-      raise ArgumentError, 'signal and kernel must not be empty' if signal.empty? || kernel.empty?
+      full_convolution = Numo::Pocketfft.fftconvolve(signal, kernel.reverse)
+
+      Numo::SFloat.cast(full_convolution[*ranges])
     end
 
-    def validate_shapes!(signal, kernel)
-      raise ArgumentError, 'signal and kernel must have equal rank' unless signal.ndim == kernel.ndim
-      raise ArgumentError, "maximum supported rank is #{MAX_RANK}" if signal.ndim > MAX_RANK
-      return if signal.shape.zip(kernel.shape).all? { |signal_size, kernel_size| signal_size >= kernel_size }
+    def convolve_fft_wrap(signal, kernel, plan)
+      signal_value = Numo::DFloat.cast(signal)
+      folded_kernel = fold_kernel(Numo::DFloat.cast(kernel), signal.shape, plan.anchors)
+      spectrum = Numo::Pocketfft.fftn(signal_value) * Numo::Pocketfft.fftn(folded_kernel).conj
 
-      raise ArgumentError, 'kernel must not be larger than signal in any dimension'
+      Numo::SFloat.cast(Numo::Pocketfft.ifftn(spectrum).real)
     end
+
+    def fold_kernel(kernel, signal_shape, anchors)
+      folded = Numo::DFloat.zeros(*signal_shape)
+      kernel.flatten.each_with_index do |value, flat_index|
+        target = folded_kernel_target(flat_index, kernel.shape, signal_shape, anchors)
+        folded[*target] = folded[*target] + value
+      end
+      folded
+    end
+
+    def folded_kernel_target(flat_index, kernel_shape, signal_shape, anchors)
+      remainder = flat_index
+      Array.new(kernel_shape.length).tap do |target|
+        (kernel_shape.length - 1).downto(0) do |axis|
+          coordinate = remainder % kernel_shape[axis]
+          remainder /= kernel_shape[axis]
+          target[axis] = (coordinate - anchors[axis]) % signal_shape[axis]
+        end
+      end
+    end
+
+    def fft_preparation_size(plan, signal, kernel)
+      return signal.size + kernel.size if plan.wrap?
+      return 0 if plan.valid?
+
+      plan.extended_size
+    end
+
+    # rubocop:enable Metrics/ParameterLists
   end
 end

--- a/lib/convolver/operation_plan.rb
+++ b/lib/convolver/operation_plan.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+# Internal planning and extension support for Convolver's public operations.
+module Convolver
+  # Distinguishes an omitted fill_value keyword from an explicitly supplied
+  # value. This lets non-constant boundaries reject even an explicit zero.
+  UNSPECIFIED_FILL = Object.new.freeze
+
+  # Validated dimensions and boundary-extension details for one correlation.
+  class OperationPlan # rubocop:disable Metrics/ClassLength
+    MODES = %i[valid same full].freeze
+    BOUNDARIES = %i[constant nearest reflect mirror wrap].freeze
+    SIZE_MAX = (1 << ([0].pack('J').bytesize * 8)) - 1
+
+    attr_reader :mode, :boundary, :fill_value, :origins, :anchors,
+                :padding_before, :padding_after, :result_shape,
+                :extended_shape, :result_size, :extended_size
+
+    # The public operation has two positional and four keyword parameters.
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(signal, kernel, mode:, boundary:, fill_value:, origin:)
+      validate_inputs!(signal, kernel)
+      validate_vocabulary!(mode, boundary)
+      assign_options(signal, kernel, mode, boundary, fill_value, origin)
+      validate_combinations!(signal.shape, kernel.shape)
+      calculate_shapes(signal.shape, kernel.shape)
+      validate_sizes!
+    end
+
+    def assign_options(signal, kernel, mode, boundary, fill_value, origin)
+      @mode = mode
+      @boundary = boundary
+      @fill_value_given = !fill_value.equal?(UNSPECIFIED_FILL)
+      @fill_value = normalize_fill_value(fill_value)
+      @origins = normalize_origins(origin, signal.ndim)
+      @anchors = kernel.shape.zip(@origins).map.with_index do |(kernel_size, axis_origin), axis|
+        normalize_anchor(kernel_size, axis_origin, axis)
+      end.freeze
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    def valid?
+      mode == :valid
+    end
+
+    def wrap?
+      mode == :same && boundary == :wrap
+    end
+
+    def linear_fft_shape(kernel_shape)
+      checked_shape(
+        extended_shape.zip(kernel_shape).map { |signal_size, kernel_size| signal_size + kernel_size - 1 },
+        'FFT shape'
+      )
+    end
+
+    def linear_fft_size(kernel_shape)
+      checked_product(linear_fft_shape(kernel_shape), 'FFT size')
+    end
+
+    def extend_signal(signal)
+      return signal if valid?
+
+      source = Numo::SFloat.cast(signal)
+      return constant_extension(source) if boundary == :constant
+
+      source[*extension_indices]
+    end
+
+    private
+
+    def validate_inputs!(signal, kernel)
+      unless signal.is_a?(Numo::NArray) && kernel.is_a?(Numo::NArray)
+        raise ArgumentError, 'signal and kernel must be Numo::NArray values'
+      end
+      raise ArgumentError, 'signal and kernel must not be empty' if signal.empty? || kernel.empty?
+      raise ArgumentError, 'signal and kernel must have equal rank' unless signal.ndim == kernel.ndim
+      raise ArgumentError, "maximum supported rank is #{MAX_RANK}" if signal.ndim > MAX_RANK
+    end
+
+    def validate_vocabulary!(mode, boundary)
+      raise ArgumentError, "mode must be one of #{MODES.inspect}" unless MODES.include?(mode)
+      return if BOUNDARIES.include?(boundary)
+
+      raise ArgumentError, "boundary must be one of #{BOUNDARIES.inspect}"
+    end
+
+    def normalize_fill_value(fill_value)
+      value = fill_value.equal?(UNSPECIFIED_FILL) ? 0.0 : fill_value
+      unless value.is_a?(Numeric) && !value.is_a?(Complex)
+        raise ArgumentError, 'fill_value must be a real numeric value'
+      end
+
+      value.to_f
+    end
+
+    def normalize_origins(origin, rank)
+      origins = case origin
+                when Integer then Array.new(rank, origin)
+                when Array then origin.dup
+                else
+                  raise ArgumentError, 'origin must be an Integer or an Array of one Integer per dimension'
+                end
+
+      unless origins.length == rank && origins.all?(Integer)
+        raise ArgumentError, 'origin must contain one Integer per dimension'
+      end
+
+      origins.freeze
+    end
+
+    def normalize_anchor(kernel_size, origin, axis)
+      anchor = (kernel_size / 2) + origin
+      return anchor if anchor.between?(0, kernel_size - 1)
+
+      raise ArgumentError,
+            "origin #{origin} is out of range for kernel dimension #{axis} of size #{kernel_size}"
+    end
+
+    def validate_combinations!(signal_shape, kernel_shape)
+      validate_mode_combination!(signal_shape, kernel_shape)
+      validate_fill_combination!
+      validate_origin_combination!
+    end
+
+    def validate_mode_combination!(signal_shape, kernel_shape)
+      return validate_valid_options!(signal_shape, kernel_shape) if mode == :valid
+      return unless mode == :full && boundary != :constant
+
+      raise ArgumentError, 'mode: :full only supports boundary: :constant'
+    end
+
+    def validate_fill_combination!
+      return unless boundary != :constant && @fill_value_given
+
+      raise ArgumentError, 'fill_value is only supported with boundary: :constant'
+    end
+
+    def validate_origin_combination!
+      return if mode == :same || origins.all?(&:zero?)
+
+      raise ArgumentError, 'nonzero origin is only supported with mode: :same'
+    end
+
+    def validate_valid_options!(signal_shape, kernel_shape)
+      unless signal_shape.zip(kernel_shape).all? { |signal_size, kernel_size| signal_size >= kernel_size }
+        raise ArgumentError, 'kernel must not be larger than signal in any dimension'
+      end
+      raise ArgumentError, 'mode: :valid only supports boundary: :constant' unless boundary == :constant
+      raise ArgumentError, 'mode: :valid requires fill_value: 0' unless fill_value.zero?
+    end
+
+    def calculate_shapes(signal_shape, kernel_shape)
+      @padding_before, @padding_after, @result_shape = case mode
+                                                       when :valid then valid_shapes(signal_shape, kernel_shape)
+                                                       when :same then same_shapes(signal_shape, kernel_shape)
+                                                       when :full then full_shapes(signal_shape, kernel_shape)
+                                                       end
+      @extended_shape = signal_shape.zip(padding_before, padding_after).map do |signal_size, before, after|
+        signal_size + before + after
+      end
+    end
+
+    def valid_shapes(signal_shape, kernel_shape)
+      result = signal_shape.zip(kernel_shape).map do |signal_size, kernel_size|
+        signal_size - kernel_size + 1
+      end
+      zeros = Array.new(signal_shape.length, 0).freeze
+      [zeros, zeros, result]
+    end
+
+    def same_shapes(signal_shape, kernel_shape)
+      before = anchors.dup.freeze
+      after = kernel_shape.zip(anchors).map { |kernel_size, anchor| kernel_size - 1 - anchor }.freeze
+      [before, after, signal_shape.dup]
+    end
+
+    def full_shapes(signal_shape, kernel_shape)
+      padding = kernel_shape.map { |kernel_size| kernel_size - 1 }.freeze
+      result = signal_shape.zip(kernel_shape).map { |signal_size, kernel_size| signal_size + kernel_size - 1 }
+      [padding, padding, result]
+    end
+
+    def validate_sizes!
+      @padding_before, @padding_after, @result_shape, @extended_shape = [
+        [padding_before, 'padding shape'],
+        [padding_after, 'padding shape'],
+        [result_shape, 'result shape'],
+        [extended_shape, 'extended signal shape']
+      ].map { |shape, description| checked_shape(shape, description).freeze }
+      @result_size = checked_product(result_shape, 'result size')
+      @extended_size = checked_product(extended_shape, 'extended signal size')
+    end
+
+    def checked_shape(shape, description)
+      return shape if shape.all? { |size| size.between?(0, SIZE_MAX) }
+
+      raise RangeError, "#{description} exceeds native implementation limit"
+    end
+
+    def checked_product(shape, description)
+      shape.reduce(1) do |product, size|
+        if !product.zero? && size > SIZE_MAX / product
+          raise RangeError, "#{description} exceeds native implementation limit"
+        end
+
+        product * size
+      end
+    end
+
+    def constant_extension(source)
+      extended = Numo::SFloat.new(*extended_shape).fill(fill_value)
+      ranges = source.shape.zip(padding_before).map do |signal_size, before|
+        before...(before + signal_size)
+      end
+      extended[*ranges] = source
+      extended
+    end
+
+    def extension_indices
+      extended_shape.zip(padding_before).map.with_index do |(length, before), axis|
+        signal_size = extended_shape[axis] - before - padding_after[axis]
+        Array.new(length) { |offset| boundary_index(offset - before, signal_size) }
+      end
+    end
+
+    def boundary_index(position, size)
+      case boundary
+      when :nearest then position.clamp(0, size - 1)
+      when :wrap then position % size
+      when :reflect then reflect_index(position, size)
+      when :mirror then mirror_index(position, size)
+      end
+    end
+
+    def reflect_index(position, size)
+      residue = position % (2 * size)
+      residue < size ? residue : (2 * size) - 1 - residue
+    end
+
+    def mirror_index(position, size)
+      return 0 if size == 1
+
+      period = 2 * (size - 1)
+      residue = position % period
+      residue < size ? residue : period - residue
+    end
+  end
+
+  private_constant :OperationPlan, :UNSPECIFIED_FILL
+end

--- a/spec/convolver_modes_spec.rb
+++ b/spec/convolver_modes_spec.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+require 'helpers'
+
+# The intentionally direct oracle favors readability over production metrics.
+# rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/ParameterLists
+module CorrelationReference
+  CALCULATION_METHODS = %i[convolve convolve_basic convolve_fft].freeze
+  ENTRY_POINTS = (CALCULATION_METHODS + %i[predict_convolve_basic_time predict_convolve_fft_time]).freeze
+
+  module_function
+
+  def calculate(signal, kernel, mode:, boundary: :constant, fill_value: 0.0, origin: 0)
+    origins = origin.is_a?(Array) ? origin : Array.new(signal.ndim, origin)
+    anchors = kernel.shape.zip(origins).map { |size, shift| (size / 2) + shift }
+    result_shape, starts = result_layout(signal.shape, kernel.shape, anchors, mode)
+    result = Numo::SFloat.zeros(*result_shape)
+
+    coordinates(result_shape).each do |output_coordinate|
+      total = coordinates(kernel.shape).sum do |kernel_coordinate|
+        signal_coordinate = output_coordinate.zip(kernel_coordinate, starts).map(&:sum)
+        value = boundary_value(signal, signal_coordinate, boundary, fill_value)
+        value * kernel[*kernel_coordinate]
+      end
+      result[*output_coordinate] = total
+    end
+
+    result
+  end
+
+  def coordinates(shape)
+    shape.reduce([[]]) do |coordinates, size|
+      coordinates.flat_map { |prefix| size.times.map { |index| prefix + [index] } }
+    end
+  end
+
+  def result_layout(signal_shape, kernel_shape, anchors, mode)
+    case mode
+    when :valid
+      [signal_shape.zip(kernel_shape).map { |signal, kernel| signal - kernel + 1 }, Array.new(signal_shape.length, 0)]
+    when :same
+      [signal_shape, anchors.map(&:-@)]
+    when :full
+      [signal_shape.zip(kernel_shape).map { |signal, kernel| signal + kernel - 1 },
+       kernel_shape.map { |kernel| 1 - kernel }]
+    end
+  end
+
+  def boundary_value(signal, coordinate, boundary, fill_value)
+    return signal[*coordinate] if coordinate.zip(signal.shape).all? { |index, size| index.between?(0, size - 1) }
+    return fill_value if boundary == :constant
+
+    mapped = coordinate.zip(signal.shape).map { |index, size| boundary_index(index, size, boundary) }
+    signal[*mapped]
+  end
+
+  def boundary_index(index, size, boundary)
+    case boundary
+    when :nearest then index.clamp(0, size - 1)
+    when :wrap then index % size
+    when :reflect
+      residue = index % (2 * size)
+      residue < size ? residue : (2 * size) - 1 - residue
+    when :mirror
+      return 0 if size == 1
+
+      period = 2 * (size - 1)
+      residue = index % period
+      residue < size ? residue : period - residue
+    end
+  end
+end
+# rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/ParameterLists
+
+describe Convolver do
+  CorrelationReference::CALCULATION_METHODS.each do |method_name|
+    describe ".#{method_name} output and boundary options" do
+      it 'supports valid, same, and full constant output extents' do
+        signal = NArray[1, 2, 4]
+        kernel = NArray[3, 5]
+
+        valid = described_class.public_send(method_name, signal, kernel)
+        same = described_class.public_send(method_name, signal, kernel, mode: :same)
+        full = described_class.public_send(method_name, signal, kernel, mode: :full)
+
+        expect(valid).to be_narray_like NArray[13, 26]
+        expect(same).to be_narray_like NArray[5, 13, 26]
+        expect(full).to be_narray_like NArray[5, 13, 26, 12]
+        expect([valid.class, same.class, full.class]).to all(eq(Numo::SFloat))
+      end
+
+      it 'uses nonzero constant fill throughout a full result' do
+        full = described_class.public_send(
+          method_name, NArray[1, 2], NArray[3, 5], mode: :full, fill_value: 10
+        )
+        same = described_class.public_send(
+          method_name, NArray[1, 2, 4], NArray[3, 5], mode: :same, fill_value: -2
+        )
+
+        expect(full).to be_narray_like NArray[35, 13, 56]
+        expect(same).to be_narray_like NArray[-1, 13, 26]
+      end
+
+      it 'implements every same-sized boundary sequence exactly' do
+        signal = NArray[1, 2, 4]
+        kernel = NArray[1, 10, 100]
+        expected = {
+          constant: NArray[210, 421, 42],
+          nearest: NArray[211, 421, 442],
+          reflect: NArray[211, 421, 442],
+          mirror: NArray[212, 421, 242],
+          wrap: NArray[214, 421, 142]
+        }
+
+        expected.each do |boundary, values|
+          result = described_class.public_send(method_name, signal, kernel, mode: :same, boundary:)
+          expect(result).to be_narray_like values
+        end
+      end
+
+      it 'applies positive and negative kernel origins' do
+        signal = NArray[1, 2, 4, 8]
+        kernel = NArray[1, 10, 100]
+
+        positive = described_class.public_send(method_name, signal, kernel, mode: :same, origin: 1)
+        negative = described_class.public_send(method_name, signal, kernel, mode: :same, origin: -1)
+
+        expect(positive).to be_narray_like NArray[100, 210, 421, 842]
+        expect(negative).to be_narray_like NArray[421, 842, 84, 8]
+      end
+
+      it 'supports length-one signals and kernels wider than the signal' do
+        signal = NArray[7]
+        kernel = NArray[1, 2, 3, 4, 5]
+
+        %i[nearest reflect mirror wrap].each do |boundary|
+          result = described_class.public_send(method_name, signal, kernel, mode: :same, boundary:)
+          expect(result).to be_narray_like NArray[105]
+        end
+      end
+
+      it 'maps multidimensional corners and per-axis origins' do
+        signal = NArray[[1, 4], [2, 5], [3, 6]].transpose
+        kernel = NArray[[1, 3, 5], [2, 4, 6]].transpose
+        origin = [1, -1]
+
+        %i[constant nearest reflect mirror wrap].each do |boundary|
+          expected = CorrelationReference.calculate(signal, kernel, mode: :same, boundary:, origin:)
+          result = described_class.public_send(method_name, signal, kernel, mode: :same, boundary:, origin:)
+          expect(result).to be_narray_like expected
+        end
+      end
+
+      it 'handles periodic folding on odd shapes with a larger kernel' do
+        signal = NArray[2, 3, 5, 7, 11]
+        kernel = NArray[11, 13, 17, 19, 23, 29, 31]
+        expected = CorrelationReference.calculate(
+          signal, kernel, mode: :same, boundary: :wrap, origin: 2
+        )
+
+        result = described_class.public_send(
+          method_name, signal, kernel, mode: :same, boundary: :wrap, origin: 2
+        )
+
+        expect(result).to be_narray_like expected
+      end
+    end
+  end
+
+  describe 'shared option validation' do
+    let(:validation_signal) { NArray[1, 2, 4] }
+    let(:validation_kernel) { NArray[1, 10, 100] }
+
+    invalid_options = [
+      [{ mode: 'same' }, /mode must be one of/],
+      [{ mode: :unknown }, /mode must be one of/],
+      [{ mode: :same, boundary: 'wrap' }, /boundary must be one of/],
+      [{ mode: :same, boundary: :unknown }, /boundary must be one of/],
+      [{ boundary: :reflect }, /mode: :valid only supports boundary: :constant/],
+      [{ fill_value: 1 }, /mode: :valid requires fill_value: 0/],
+      [{ mode: :same, boundary: :reflect, fill_value: 0 }, /fill_value is only supported/],
+      [{ mode: :full, boundary: :wrap }, /mode: :full only supports boundary: :constant/],
+      [{ origin: 1 }, /nonzero origin is only supported with mode: :same/],
+      [{ mode: :full, origin: -1 }, /nonzero origin is only supported with mode: :same/],
+      [{ mode: :same, origin: 'left' }, /origin must be an Integer/],
+      [{ mode: :same, origin: [0, 0] }, /origin must contain one Integer per dimension/],
+      [{ mode: :same, origin: ['left'] }, /origin must contain one Integer per dimension/],
+      [{ mode: :same, origin: -2 }, /origin -2 is out of range/],
+      [{ mode: :same, origin: 2 }, /origin 2 is out of range/],
+      [{ mode: :same, fill_value: Complex(1, 2) }, /fill_value must be a real numeric value/]
+    ]
+
+    CorrelationReference::ENTRY_POINTS.each do |entry_point|
+      invalid_options.each do |options, error|
+        it "rejects #{options.inspect} through .#{entry_point}" do
+          expect { described_class.public_send(entry_point, validation_signal, validation_kernel, **options) }
+            .to raise_error(ArgumentError, error)
+        end
+      end
+    end
+
+    it 'allows large kernels for same and full through every entry point' do
+      small_signal = NArray[1, 2]
+      large_kernel = NArray[1, 2, 3]
+      all_entry_points = %i[
+        convolve convolve_basic convolve_fft predict_convolve_basic_time predict_convolve_fft_time
+      ]
+
+      all_entry_points.each do |entry_point|
+        expect { described_class.public_send(entry_point, small_signal, large_kernel, mode: :same) }
+          .not_to raise_error
+        expect { described_class.public_send(entry_point, small_signal, large_kernel, mode: :full) }
+          .not_to raise_error
+      end
+    end
+
+    it 'accepts explicitly supplied defaults for valid mode through every entry point' do
+      CorrelationReference::ENTRY_POINTS.each do |entry_point|
+        expect do
+          described_class.public_send(
+            entry_point, validation_signal, validation_kernel,
+            mode: :valid, boundary: :constant, fill_value: 0, origin: [0]
+          )
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe 'cross-implementation coverage' do
+    it 'matches an independent reference across randomized modes, boundaries, and ranks' do
+      random = Random.new(12_345)
+      cases = [
+        [[4], [3], :valid, :constant, 0.0, 0],
+        [[4], [3], :full, :constant, -0.75, 0],
+        [[4], [5], :same, :constant, 1.25, -1],
+        *%i[nearest reflect mirror wrap].map { |boundary| [[4], [5], :same, boundary, 0.0, -1] },
+        [[2, 3], [3, 2], :full, :constant, -0.75, 0],
+        [[2, 3], [3, 2], :same, :constant, 1.25, [1, -1]],
+        *%i[nearest reflect mirror wrap].map do |boundary|
+          [[2, 3], [3, 2], :same, boundary, 0.0, [1, -1]]
+        end
+      ]
+
+      cases.each do |case_data|
+        signal_shape, kernel_shape, mode, boundary, fill_value, origin = case_data
+        signal = NArray[*Array.new(signal_shape.inject(:*)) { random.rand(-2.0..3.0) }].reshape(*signal_shape)
+        kernel = NArray[*Array.new(kernel_shape.inject(:*)) { random.rand(-3.0..2.0) }].reshape(*kernel_shape)
+        expected = CorrelationReference.calculate(signal, kernel, mode:, boundary:, fill_value:, origin:)
+        options = { mode:, boundary:, origin: }
+        options[:fill_value] = fill_value if boundary == :constant
+
+        expect(described_class.convolve_basic(signal, kernel, **options)).to be_narray_like(expected, 1e-7)
+        expect(described_class.convolve_fft(signal, kernel, **options)).to be_narray_like(expected, 1e-7)
+      end
+    end
+
+    it 'supports boundary extension on higher-rank inputs' do
+      signal = NArray[*Array(1..8)].reshape(2, 2, 2)
+      kernel = NArray[*Array(1..12)].reshape(3, 2, 2)
+      expected = CorrelationReference.calculate(
+        signal, kernel, mode: :same, boundary: :mirror, origin: [1, -1, 0]
+      )
+
+      CorrelationReference::CALCULATION_METHODS.each do |method_name|
+        result = described_class.public_send(
+          method_name, signal, kernel, mode: :same, boundary: :mirror, origin: [1, -1, 0]
+        )
+        expect(result).to be_narray_like expected
+      end
+    end
+
+    it 'exposes the keyword API from each calculation and estimator method' do
+      public_methods = CorrelationReference::CALCULATION_METHODS + %i[
+        convolve_fftw3 predict_convolve_basic_time predict_convolve_fft_time
+      ]
+      expected_parameters = [
+        %i[req signal], %i[req kernel], %i[key mode], %i[key boundary],
+        %i[key fill_value], %i[key origin]
+      ]
+
+      public_methods.each do |method_name|
+        expect(described_class.method(method_name).parameters).to eq expected_parameters
+      end
+    end
+  end
+
+  describe 'algorithm selection and estimation' do
+    it 'forwards the complete requested semantics to the selected implementation' do
+      signal = NArray[1, 2, 4]
+      kernel = NArray[1, 10, 100]
+      allow(described_class).to receive(:convolve_basic).and_call_original
+
+      described_class.convolve(signal, kernel, mode: :same, boundary: :mirror, origin: -1)
+
+      expect(described_class).to have_received(:convolve_basic)
+        .with(signal, kernel, mode: :same, boundary: :mirror, origin: -1)
+    end
+
+    it 'accounts for extension and periodic transform sizes' do
+      signal = NArray.ones(9)
+      kernel = NArray.ones(5)
+
+      valid_basic = described_class.predict_convolve_basic_time(signal, kernel)
+      same_basic = described_class.predict_convolve_basic_time(signal, kernel, mode: :same)
+      same_fft = described_class.predict_convolve_fft_time(signal, kernel, mode: :same)
+      wrap_fft = described_class.predict_convolve_fft_time(signal, kernel, mode: :same, boundary: :wrap)
+
+      expect(same_basic).to be > valid_basic
+      expect(wrap_fft).to be > 0
+      expect(wrap_fft).to be < same_fft
+    end
+  end
+
+  it 'keeps the native valid primitive private' do
+    expect(described_class.private_methods).to include(:convolve_basic_valid)
+    expect(described_class).not_to respond_to(:convolve_basic_valid)
+  end
+end

--- a/spec/convolver_spec.rb
+++ b/spec/convolver_spec.rb
@@ -67,12 +67,15 @@ describe Convolver do
   end
 
   describe '.convolve_fftw3' do
-    it 'warns and delegates to .convolve_fft' do
+    it 'warns and delegates all options to .convolve_fft' do
       signal = Numo::SFloat[0.3, 0.4, 0.5]
       kernel = Numo::SFloat[1.3, -0.5]
+      allow(described_class).to receive(:convolve_fft).and_call_original
 
-      expect { described_class.convolve_fftw3(signal, kernel) }
+      expect { described_class.convolve_fftw3(signal, kernel, mode: :full, fill_value: -1) }
         .to output(/deprecated; use \.convolve_fft/).to_stderr
+      expect(described_class).to have_received(:convolve_fft)
+        .with(signal, kernel, mode: :full, boundary: :constant, fill_value: -1, origin: 0)
     end
   end
 end


### PR DESCRIPTION
## Summary

- add `:valid`, `:same`, and `:full` output modes across calculation and estimator APIs
- add constant, nearest, reflect, mirror, and wrap boundary handling with nonzero constant fill and scalar or per-axis kernel origins
- route direct and PocketFFT implementations through a shared validation and extension plan
- add origin-aware circular PocketFFT correlation for periodic same-sized output
- document the public behavior and add deterministic plus randomized regression coverage

## Why

Convolver previously returned only valid cross-correlations, leaving callers to implement padding, boundary mapping, cropping, and even-kernel alignment themselves. This exposes those concepts as consistent public keywords while preserving existing two-argument behavior.

## API impact

All calculation methods and both estimator methods now accept `mode:`, `boundary:`, `fill_value:`, and `origin:`. Mode and boundary values are symbols only, and incompatible combinations are rejected rather than ignored.

## Validation

- `bundle exec rake` — 139 examples, 0 failures
- `bundle exec rubocop` — 12 files, no offenses
- `bundle exec rake c:lint` — strict native compilation clean
